### PR TITLE
RenameSuggestion

### DIFF
--- a/src/main/java/eu/koboo/en2do/repository/methods/pagination/Pagination.java
+++ b/src/main/java/eu/koboo/en2do/repository/methods/pagination/Pagination.java
@@ -68,7 +68,7 @@ public class Pagination {
      * @param page The requested page
      * @return The used Pagination object
      */
-    public @NotNull Pagination page(long page) {
+    public @NotNull Pagination setPage(long page) {
         this.page = page;
         return this;
     }

--- a/src/test/java/eu/koboo/en2do/test/customer/async/CustomerAsyncPageAllTest.java
+++ b/src/test/java/eu/koboo/en2do/test/customer/async/CustomerAsyncPageAllTest.java
@@ -39,7 +39,7 @@ public class CustomerAsyncPageAllTest extends CustomerRepositoryTest {
     @Test
     @Order(3)
     public void findCustomer() {
-        repository.asyncPageAll(Pagination.of(5).page(2)).thenAccept(customerList -> {
+        repository.asyncPageAll(Pagination.of(5).setPage(2)).thenAccept(customerList -> {
             assertNotNull(customerList);
             assertFalse(customerList.isEmpty());
             assertEquals(5, customerList.size());

--- a/src/test/java/eu/koboo/en2do/test/customer/predefined/CustomerPageAllTest.java
+++ b/src/test/java/eu/koboo/en2do/test/customer/predefined/CustomerPageAllTest.java
@@ -40,7 +40,7 @@ public class CustomerPageAllTest extends CustomerRepositoryTest {
     public void findCustomer() {
         List<Customer> customerList = repository.pageAll(
             Pagination.of(5)
-                .page(2)
+                .setPage(2)
         );
         assertNotNull(customerList);
         assertFalse(customerList.isEmpty());


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:

```java
/* Non-descriptive Method Name in src/main/java/eu/koboo/en2do/repository/methods/pagination/Pagination.java*/
    public @NotNull Pagination page(long page) {
        this.page = page;
        return this;
    }
```

We consider "page" as non-descriptive because it only contains a noun, and we cannot guess the action (e.g., get, set, load) of this method without looking into the method body. 
We propose to rename this method to "setPage" because this method is to set the field "page" with the parameter "page" and returns the "Pagination" object (it is more like a setter method).


Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.